### PR TITLE
Bug fixes

### DIFF
--- a/menus.py
+++ b/menus.py
@@ -230,6 +230,7 @@ class SplashScreen(Menu):
                               f'Please make sure your Discord client is running.'
             self.update()
 
+            time.sleep(4)
             self._connect_presence()
         else:
             self._login()

--- a/menus.py
+++ b/menus.py
@@ -230,7 +230,7 @@ class SplashScreen(Menu):
                               f'Please make sure your Discord client is running.'
             self.update()
 
-            self.exec_after(4, self._connect_presence)
+            self._connect_presence()
         else:
             self._login()
 

--- a/riitag/presence.py
+++ b/riitag/presence.py
@@ -56,7 +56,7 @@ class RPCHandler:
     def connect(self):
         try:
             self._presence.connect()
-        except (ConnectionRefusedError, pypresence.InvalidPipe):
+        except (ConnectionRefusedError, pypresence.PyPresenceException):
             self._is_connected = False
             return False
         else:

--- a/riitag/user.py
+++ b/riitag/user.py
@@ -92,11 +92,11 @@ class User:
 
     def fetch_riitag(self):
         url = RIITAG_ENDPOINT.format(self.id)
-        r = requests.get(url, headers=HEADERS)
 
         try:
+            r = requests.get(url, headers=HEADERS)
             r.raise_for_status()
-        except requests.exceptions.HTTPError:
+        except requests.exceptions.RequestException:
             self.riitag = None
 
             return

--- a/riitag/user.py
+++ b/riitag/user.py
@@ -5,7 +5,7 @@ import requests
 
 from .exceptions import RiitagNotFoundError
 
-RIITAG_ENDPOINT = 'http://tag.rc24.xyz/{}/json'
+RIITAG_ENDPOINT = 'http://tag.rc24.xyz/api/user/{}'
 TITLES_URL = 'https://www.gametdb.com/wiitdb.txt?LANG=EN'
 HEADERS = {'User-Agent': 'RiiTag-RPC WatchThread v1'}
 

--- a/riitag/watcher.py
+++ b/riitag/watcher.py
@@ -61,6 +61,8 @@ class RiitagWatcher(Thread):
         return riitag
 
     def run(self):
+        self._last_riitag = self._get_riitag()
+
         while self._run:
             new_riitag = self._last_riitag
 

--- a/riitag/watcher.py
+++ b/riitag/watcher.py
@@ -72,6 +72,10 @@ class RiitagWatcher(Thread):
                 self._last_check = now
 
                 new_riitag = self._get_riitag()
+                if new_riitag is None:
+                    # some error while fetching, probably server issue
+                    time.sleep(5)
+                    continue
 
             if self._last_riitag:
                 last_play_time = self._last_riitag.last_played.time

--- a/riitag/watcher.py
+++ b/riitag/watcher.py
@@ -4,6 +4,7 @@ from threading import Thread
 from typing import TYPE_CHECKING
 
 from prompt_toolkit.application import get_app
+from pypresence.exceptions import PyPresenceException
 
 from .exceptions import RiitagNotFoundError
 from .preferences import Preferences
@@ -83,7 +84,12 @@ class RiitagWatcher(Thread):
                     new_riitag.outdated = True
 
             if new_riitag != self._last_riitag:
-                self._update_callback(new_riitag)
+                try:
+                    self._update_callback(new_riitag)
+                except PyPresenceException:
+                    # failed to set presence. We will retry later.
+                    time.sleep(5)
+                    continue
 
                 self._last_riitag = new_riitag
 

--- a/start.py
+++ b/start.py
@@ -123,7 +123,7 @@ with sentry_sdk.configure_scope() as scope:
 
 class RiiTagApplication(Application):
     def __init__(self, *args, **kwargs):
-        self._current_menu: menus.Menu = None
+        self._current_menu: menus.Menu | None = None
         self._float_message_layout = None
 
         self.preferences = preferences.Preferences.load('cache/prefs.json')
@@ -139,10 +139,10 @@ class RiiTagApplication(Application):
                          layout=Layout(DynamicContainer(self._get_layout)),
                          full_screen=True)
 
-        self.token: oauth2.OAuth2Token = None
-        self.user: user.User = None
+        self.token: oauth2.OAuth2Token | None = None
+        self.user: user.User | None = None
 
-        self.riitag_watcher: watcher.RiitagWatcher = None
+        self.riitag_watcher: watcher.RiitagWatcher | None = None
 
         self.oauth_client.start_server(CONFIG.get('port', 4000))
 


### PR DESCRIPTION
Fixes several smaller bugs

- Should fix occasional `cannot enter context: is already entered` error loop
  - Still needs more testing, please report if this works. Very inconsistent issue.
- Outdated RiiTags are no longer shown for the first ~10 seconds after startup
- API endpoint has been updated which speeds up riitag user lookups
- Refetch RiiTag if an error occurs instead of crashing
- Adds friendly exception message in case something does go wrong
- Handle more exceptions related to connecting to Discord and (re)setting presences
- Handle exceptions induced by request errors
- User IDs are now stored in the cache directory so they won't be overwritten on each execution
- The program will now tell you when it failed to create a cache directory, instead of simply crashing

closes #20, closes #14, closes #11